### PR TITLE
Iodide tests and other stuff

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export PYTHONPATH="/app:/extension/src:/usr/local/lib/python2.7/site-packages/:$PYTHONPATH"
+export PYTHONPATH="/app:$PYTHONPATH"
 
 # make sure the npm clean command is only removing the content of /app/client/dist
 # and not the directory itself so mounting it works as expected

--- a/src/redash_stmo/integrations/iodide/bundle/IodideButton.jsx
+++ b/src/redash_stmo/integrations/iodide/bundle/IodideButton.jsx
@@ -36,7 +36,7 @@ class IodideButton extends React.Component {
     this.iodideWindow = window.open('', '_blank');
 
     const settingsPromise = this.getHandledFetch(`${this.apiBase}settings`);
-    const notebookPromise = this.getHandledFetch(`${this.apiBase}${queryID}/notebook`);
+    const notebookPromise = this.getHandledFetch(`${this.apiBase}${queryID}/notebook`, 'POST');
 
     Promise.all([settingsPromise, notebookPromise])
       .then(([{ iodideURL }, { id }]) => {
@@ -58,8 +58,8 @@ class IodideButton extends React.Component {
     this.setState({ showSpinner: false });
   };
 
-  getHandledFetch = url => (
-    fetch(url).then(this.handleFetchResponse).catch(() => {
+  getHandledFetch = (url, method = 'GET') => (
+    fetch(url, {method}).then(this.handleFetchResponse).catch(() => {
       this.handleFetchError();
     })
   );

--- a/src/redash_stmo/integrations/iodide/extension.py
+++ b/src/redash_stmo/integrations/iodide/extension.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 import requests
-import json
 import logging
 import os
 
@@ -19,13 +18,17 @@ logger = logging.getLogger(__name__)
 
 
 class IodideNotebookResource(BaseResource):
+    TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), 'iodide-notebook.iomd.j2')
+
     @require_permission("view_query")
-    def get(self, query_id):
+    def post(self, query_id):
         query = get_object_or_404(
-            Query.get_by_id,
+            Query.get_by_id_and_org,
             query_id,
+            self.current_org,
         )
-        with open(os.path.join(os.path.dirname(__file__), 'iodide-notebook.iomd.j2'), "r") as template:
+
+        with open(self.TEMPLATE_PATH, "r") as template:
             source = template.read()
             context = {
                 "query_id": query_id,

--- a/src/redash_stmo/integrations/iodide/extension.py
+++ b/src/redash_stmo/integrations/iodide/extension.py
@@ -41,8 +41,8 @@ class IodideNotebookResource(BaseResource):
             "title": query.name,
             "content": rendered_template,
         }
-        result = requests.post(settings.IODIDE_NOTEBOOK_API_URL, headers=headers, data=data)
-        return json.loads(result.content)
+        response = requests.post(settings.IODIDE_NOTEBOOK_API_URL, headers=headers, data=data)
+        return response.json()
 
 
 class IodideSettingsResource(BaseResource):

--- a/src/redash_stmo/settings.py
+++ b/src/redash_stmo/settings.py
@@ -21,21 +21,13 @@ REMOTE_GROUPS_ALLOWED = set_from_string(
 )
 
 # The base URL of Mozilla's private Iodide instance
-IODIDE_URL = os.environ.get(
-    "REDASH_IODIDE_URL"
-)
+IODIDE_URL = os.environ.get("REDASH_IODIDE_URL", "")
 
 # The Iodide API endpoint to hit to create a new notebook
-IODIDE_NOTEBOOK_API_URL = os.environ.get(
-    "REDASH_IODIDE_NOTEBOOK_API_URL"
-)
+IODIDE_NOTEBOOK_API_URL = os.environ.get("REDASH_IODIDE_NOTEBOOK_API_URL", "")
 
 # The auth token that this extension uses to create new Iodide notebooks
-IODIDE_AUTH_TOKEN = os.environ.get(
-    "REDASH_IODIDE_AUTH_TOKEN"
-)
+IODIDE_AUTH_TOKEN = os.environ.get("REDASH_IODIDE_AUTH_TOKEN", "")
 
 # The API key that Iodide uses to fetch data from Redash
-IODIDE_DEFAULT_API_KEY = os.environ.get(
-    "REDASH_IODIDE_DEFAULT_API_KEY"
-)
+IODIDE_DEFAULT_API_KEY = os.environ.get("REDASH_IODIDE_DEFAULT_API_KEY", "")

--- a/tests/integrations/test_iodide.py
+++ b/tests/integrations/test_iodide.py
@@ -1,0 +1,55 @@
+import json
+import os
+import mock
+
+from tests import BaseTestCase
+
+from mock import patch
+from six.moves import reload_module
+from redash_stmo import settings
+
+
+class TestIodideIntegration(BaseTestCase):
+    SETTING_OVERRIDES = {"REDASH_IODIDE_URL": "https://example.com/"}
+
+    def setUp(self):
+        super(TestIodideIntegration, self).setUp()
+        variables = self.SETTING_OVERRIDES.copy()
+        with patch.dict(os.environ, variables):
+            reload_module(settings)
+
+        # Queue a cleanup routine that reloads the settings without overrides
+        # once the test ends
+        self.addCleanup(lambda: reload_module(settings))
+
+    def test_settings(self):
+        admin = self.factory.create_admin()
+
+        rv = self.make_request("get", "/api/integrations/iodide/settings", user=admin)
+        self.assertEquals(rv.status_code, 200)
+        self.assertEquals(
+            rv.json, {"iodideURL": self.SETTING_OVERRIDES["REDASH_IODIDE_URL"]}
+        )
+
+    @mock.patch("requests.post")
+    def test_notebook_post(self, mock_post):
+        admin = self.factory.create_admin()
+        data_source = self.factory.create_data_source()
+        query = self.factory.create_query(
+            user=admin, data_source=data_source, query_text="select * from events"
+        )
+
+        mock_value = {"id": query.id}
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.text = json.dumps(mock_value)
+        mock_json = mock.Mock()
+        mock_json.return_value = mock_value
+        mock_response.json = mock_json
+        mock_post.return_value = mock_response
+
+        rv = self.make_request(
+            "post", "/api/integrations/iodide/%s/notebook" % query.id, user=admin
+        )
+        self.assertEquals(rv.status_code, 200)
+        self.assertEquals(rv.json, {"id": query.id})


### PR DESCRIPTION
 Add some tests for Iodide.

- Also use POST for creating the notebook in the extension API.
- Renamed js file to jsx to follow upstream practices.
- Add entrypoints to setup.py again to make extension work.

@openjck This is a pull request to your fork of the redash-stmo repo. Please just open PRs and branches in the main repo the next time, so it's easier to collaborate on this.

I've updated the JS to use POST to create the notebook, can you check if that change makes sense and if the JS changes look alright to you?